### PR TITLE
perf: backport "nvk: Enable compression"

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+mesa (24.3.0-1deepin6) unstable; urgency=medium
+
+  * perf: backport "nvk: Enable compression"
+
+ -- WangYuli <wangyl5933@chinaunicom.cn>  Fri, 19 Dec 2025 13:47:10 +0800
+
 mesa (24.3.0-1deepin5) unstable; urgency=medium
 
   * fix: race condition of ORCJIT LLVMpipe

--- a/debian/patches/backports/0001-deepin-nvk-Add-prerequisites-for-compression-support.patch
+++ b/debian/patches/backports/0001-deepin-nvk-Add-prerequisites-for-compression-support.patch
@@ -1,0 +1,144 @@
+From 7499ff71b0e1323f05719b202bcbb14b731aaf02 Mon Sep 17 00:00:00 2001
+From: WangYuli <wangyl5933@chinaunicom.cn>
+Date: Fri, 19 Dec 2025 10:41:57 +0800
+Subject: [PATCH 1/3] deepin: nvk: Add prerequisites for compression support
+ backport
+
+Add the following infrastructure needed to backport compression commits:
+
+- nouveau_device: Add nouveau_version field to track kernel driver version
+- nvk_image: Add can_compress and is_compressed fields
+- nvk_device_memory: Add dedicated_image field and nvk_image forward declaration
+- NIL image.rs: Add IMAGE_USAGE_UNCOMPRESSED_BIT flag and compressed_pte_kind field
+
+These changes are required as prerequisites for the upstream compression
+feature commits.
+
+Signed-off-by: WangYuli <wangyl5933@chinaunicom.cn>
+---
+ src/nouveau/nil/image.rs               | 12 ++++++++++++
+ src/nouveau/vulkan/nvk_device_memory.h |  5 +++++
+ src/nouveau/vulkan/nvk_image.h         | 12 ++++++++++++
+ src/nouveau/winsys/nouveau_device.c    |  2 ++
+ src/nouveau/winsys/nouveau_device.h    |  5 +++++
+ 5 files changed, 36 insertions(+)
+
+diff --git a/src/nouveau/nil/image.rs b/src/nouveau/nil/image.rs
+index 3f4101fc3b4..73544224135 100644
+--- a/src/nouveau/nil/image.rs
++++ b/src/nouveau/nil/image.rs
+@@ -16,6 +16,7 @@ pub type ImageUsageFlags = u8;
+ pub const IMAGE_USAGE_2D_VIEW_BIT: ImageUsageFlags = 1 << 0;
+ pub const IMAGE_USAGE_LINEAR_BIT: ImageUsageFlags = 1 << 1;
+ pub const IMAGE_USAGE_SPARSE_RESIDENCY_BIT: ImageUsageFlags = 1 << 2;
++pub const IMAGE_USAGE_UNCOMPRESSED_BIT: ImageUsageFlags = 1 << 3;
+ 
+ #[derive(Clone, Debug, Copy, PartialEq, Default)]
+ #[repr(u8)]
+@@ -180,6 +181,7 @@ pub struct Image {
+     pub compressed: bool,
+     pub tile_mode: u16,
+     pub pte_kind: u8,
++    pub compressed_pte_kind: u8,
+ }
+ 
+ impl Image {
+@@ -253,6 +255,7 @@ impl Image {
+             compressed: false,
+             tile_mode: 0,
+             pte_kind: 0,
++            compressed_pte_kind: 0,
+             mip_tail_first_lod: 0,
+         };
+ 
+@@ -353,6 +356,15 @@ impl Image {
+                 image.compressed,
+             );
+ 
++            // Always compute compressed_pte_kind for potential future use
++            // (e.g., dedicated allocations with compression)
++            image.compressed_pte_kind = Self::choose_pte_kind(
++                dev,
++                info.format,
++                info.samples,
++                true, // compressed = true
++            );
++
+             if info.modifier != DRM_FORMAT_MOD_INVALID {
+                 let bl_mod =
+                     BlockLinearModifier::try_from(info.modifier).unwrap();
+diff --git a/src/nouveau/vulkan/nvk_device_memory.h b/src/nouveau/vulkan/nvk_device_memory.h
+index 4d2f751f111..b0e665bd18f 100644
+--- a/src/nouveau/vulkan/nvk_device_memory.h
++++ b/src/nouveau/vulkan/nvk_device_memory.h
+@@ -13,10 +13,15 @@
+ 
+ struct nvkmd_mem;
+ 
++struct nvk_image;
++
+ struct nvk_device_memory {
+    struct vk_device_memory vk;
+ 
+    struct nvkmd_mem *mem;
++
++   /** Dedicated image for this memory allocation, if any */
++   struct nvk_image *dedicated_image;
+ };
+ 
+ VK_DEFINE_NONDISP_HANDLE_CASTS(nvk_device_memory, vk.base, VkDeviceMemory,
+diff --git a/src/nouveau/vulkan/nvk_image.h b/src/nouveau/vulkan/nvk_image.h
+index 1222485c935..9f876fdaa3e 100644
+--- a/src/nouveau/vulkan/nvk_image.h
++++ b/src/nouveau/vulkan/nvk_image.h
+@@ -79,6 +79,18 @@ struct nvk_image {
+     */
+    bool disjoint;
+ 
++   /** True if this image can be compressed
++    *
++    * This is set at image creation time based on image properties.
++    */
++   bool can_compress;
++
++   /** True if this image is actually compressed
++    *
++    * This is set at bind time when compression is enabled.
++    */
++   bool is_compressed;
++
+    uint8_t plane_count;
+    struct nvk_image_plane planes[3];
+ 
+diff --git a/src/nouveau/winsys/nouveau_device.c b/src/nouveau/winsys/nouveau_device.c
+index 925df476be9..4f7ea56d541 100644
+--- a/src/nouveau/winsys/nouveau_device.c
++++ b/src/nouveau/winsys/nouveau_device.c
+@@ -285,6 +285,8 @@ nouveau_ws_device_new(drmDevicePtr drm_device)
+    drmFreeVersion(ver);
+    ver = NULL;
+ 
++   device->nouveau_version = version;
++
+    if (version < 0x01000301)
+       goto out_err;
+ 
+diff --git a/src/nouveau/winsys/nouveau_device.h b/src/nouveau/winsys/nouveau_device.h
+index e986b2cfab6..1a480e69ba2 100644
+--- a/src/nouveau/winsys/nouveau_device.h
++++ b/src/nouveau/winsys/nouveau_device.h
+@@ -27,6 +27,11 @@ struct nouveau_ws_device {
+    struct hash_table *bos;
+ 
+    bool has_vm_bind;
++
++   /* Nouveau kernel driver version, packed as:
++    * (major << 24) | (minor << 8) | patchlevel
++    */
++   uint32_t nouveau_version;
+ };
+ 
+ struct nouveau_ws_device *nouveau_ws_device_new(struct _drmDevice *drm_device);
+-- 
+2.51.0
+

--- a/debian/patches/backports/0002-nvk-Enable-compression.patch
+++ b/debian/patches/backports/0002-nvk-Enable-compression.patch
@@ -1,0 +1,306 @@
+From f50e082a66d75c0048125576d054171f937b0e9e Mon Sep 17 00:00:00 2001
+From: Mohamed Ahmed <mohamedahmedegypt2001@gmail.com>
+Date: Fri, 19 Dec 2025 10:45:42 +0800
+Subject: [PATCH 2/3] nvk: Enable compression
+
+Enables compression for select images. Additionally, we get large (64K), and
+huge (2M) pages as a bonus as the hardware can only do compression on these page
+sizes. However, due to nouveau limitations, this means that we are limited to
+enabling it on things pinned to VRAM. Fortunately, this works out for us as we
+can enable it for color, Z/S, and storage images, which are the main types
+to benefit from compression as they're write heavy.
+
+Unfortunately, this means that we need to handle the memory allocation in a
+delicate way, as the Vulkan API is a bit restrictive in this regard, so we have
+to use dedicated allocations for compression/larger pages.
+
+Reviewed-by: Mel Henning <mhenning@darkrefraction.com>
+Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/36450>
+Signed-off-by: WangYuli <wangyl5933@chinaunicom.cn>
+---
+ src/nouveau/vulkan/nvk_device_memory.c        |  51 ++++++--
+ src/nouveau/vulkan/nvk_image.c                | 109 ++++++++++++++++--
+ .../vulkan/nvkmd/nouveau/nvkmd_nouveau_pdev.c |   4 +
+ src/nouveau/vulkan/nvkmd/nvkmd.h              |   1 +
+ 4 files changed, 145 insertions(+), 20 deletions(-)
+
+diff --git a/src/nouveau/vulkan/nvk_device_memory.c b/src/nouveau/vulkan/nvk_device_memory.c
+index 9d0d6e48e05..5ca3243bb5e 100644
+--- a/src/nouveau/vulkan/nvk_device_memory.c
++++ b/src/nouveau/vulkan/nvk_device_memory.c
+@@ -41,11 +41,15 @@ const VkExternalMemoryProperties nvk_dma_buf_mem_props = {
+ 
+ static enum nvkmd_mem_flags
+ nvk_memory_type_flags(const VkMemoryType *type,
+-                      VkExternalMemoryHandleTypeFlagBits handle_types)
++                      VkExternalMemoryHandleTypeFlagBits handle_types,
++                      bool pinned_to_vram)
+ {
+    enum nvkmd_mem_flags flags = 0;
+    if (type->propertyFlags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)
+-      flags = NVKMD_MEM_LOCAL;
++      if (pinned_to_vram)
++         flags = NVKMD_MEM_VRAM;
++      else
++         flags = NVKMD_MEM_LOCAL;
+    else
+       flags = NVKMD_MEM_GART;
+ 
+@@ -88,9 +92,16 @@ nvk_GetMemoryFdPropertiesKHR(VkDevice device,
+       type_bits = BITFIELD_MASK(pdev->mem_type_count);
+    } else {
+       for (unsigned t = 0; t < ARRAY_SIZE(pdev->mem_types); t++) {
+-         const enum nvkmd_mem_flags flags =
+-            nvk_memory_type_flags(&pdev->mem_types[t], handleType);
+-         if (!(flags & ~mem->flags))
++         const VkMemoryType *type = &pdev->mem_types[t];
++         const enum nvkmd_mem_flags type_flags =
++            nvk_memory_type_flags(type, handleType, false);
++
++         /* Flags required to be set on mem to be imported as type
++          *
++          * We also require the memory to be shared because all importable
++          * memory is shared.
++          */
++         if (!(type_flags & ~mem->flags))
+             type_bits |= (1 << t);
+       }
+    }
+@@ -128,15 +139,19 @@ nvk_AllocateMemory(VkDevice device,
+    if (fd_info != NULL)
+       handle_types |= fd_info->handleType;
+ 
+-   const enum nvkmd_mem_flags flags = nvk_memory_type_flags(type, handle_types);
++   bool pinned_to_vram = false;
+ 
+-   uint32_t alignment = (1ULL << 12);
+-   if (flags & NVKMD_MEM_LOCAL)
+-      alignment = (1ULL << 16);
++   /* Align to os page size (typically 4K) as a start as this works for
++    * everything, and then depending on placement and size, we either keep
++    * it as is or increase it to 64K or 2M.
++    */
++   uint32_t alignment = pdev->nvkmd->bind_align_B;
+ 
+    uint8_t pte_kind = 0, tile_mode = 0;
++   struct nvk_image *dedicated_image = NULL;
+    if (dedicated_info != NULL) {
+       VK_FROM_HANDLE(nvk_image, image, dedicated_info->image);
++      dedicated_image = image;
+       if (image != NULL &&
+           image->vk.tiling == VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT) {
+          /* This image might be shared with GL so we need to set the BO flags
+@@ -146,9 +161,25 @@ nvk_AllocateMemory(VkDevice device,
+          alignment = MAX2(alignment, image->planes[0].nil.align_B);
+          pte_kind = image->planes[0].nil.pte_kind;
+          tile_mode = image->planes[0].nil.tile_mode;
++      } else if (image != NULL && image->can_compress) {
++         /* If it's a dedicated alloc and it's not modifiers, then it's marked
++          * for compression and larger pages, so we set the pinned bit and up
++          * the alignment.
++          */
++         pinned_to_vram = true;
++         pte_kind = image->planes[0].nil.compressed_pte_kind;
++         tile_mode = image->planes[0].nil.tile_mode;
++         /* Align to 2MiB if size is >= 2MiB, otherwise align to 64KiB. */
++         if (pAllocateInfo->allocationSize >= (1ULL << 21))
++            alignment = (1ULL << 21);
++         else
++            alignment = (1ULL << 16);
+       }
+    }
+ 
++   const enum nvkmd_mem_flags flags =
++      nvk_memory_type_flags(type, handle_types, pinned_to_vram);
++
+    const uint64_t aligned_size =
+       align64(pAllocateInfo->allocationSize, alignment);
+ 
+@@ -157,6 +188,8 @@ nvk_AllocateMemory(VkDevice device,
+    if (!mem)
+       return vk_error(dev, VK_ERROR_OUT_OF_HOST_MEMORY);
+ 
++   mem->dedicated_image = dedicated_image;
++
+    if (fd_info && fd_info->handleType) {
+       assert(fd_info->handleType ==
+                VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT ||
+diff --git a/src/nouveau/vulkan/nvk_image.c b/src/nouveau/vulkan/nvk_image.c
+index 8531623c169..4418ad7d252 100644
+--- a/src/nouveau/vulkan/nvk_image.c
++++ b/src/nouveau/vulkan/nvk_image.c
+@@ -706,6 +706,63 @@ nvk_GetPhysicalDeviceSparseImageFormatProperties2(
+    }
+ }
+ 
++/* To use compression and larger page sizes, we need to signal to the kernel
++ * that the memory requested is going to be VRAM resident. However, this
++ * comes with an issue where said memory can't be evicted to host RAM under
++ * pressure, so we work around this by going with a dedicated allocation for
++ * color, Z/S, and storage image targets which are the main types that would
++ * benefit from compression as they're heavy on writes. Additionally, they
++ * also aren't the majority of memory used, so they can be safely pinned in
++ * VRAM without worrying about eviction under high pressure.
++ *
++ * There are some additional restrictions we need to keep in mind, however:
++ * 1. We can only enable this for Turing onwards because prior architectures
++ *    relied on firmware to manage the compression tags, and it's impossible to
++ *    do this on nouveau. Additionally, since compression needs kernel changes,
++ *    we can only enable it if the detected kernel supports it.
++ *
++ * 2. Given our approach depends on dedicated allocations, we can't enable
++ *    compression for sparse images as dedicated allocations are not compatible
++ *    with sparse.
++ *
++ * 3. In similar vein, we currently don't do multiplanar dedicated allocations
++ *    so we can't do compression for multi-plane YCbCr images.
++ *
++ * 4. Host copies are a complete no-go for compression as the host doesn't know
++ *    about the modified data layout nor the compression tags.
++ *
++ * 5. The API for VK_EXT_image_drm_format_modifier requires that we report the
++ *    supported modifiers in GetPhysicalDeviceFormatProperties2(). However,
++ *    since we can only know whether an image is compressed or not at bind time
++ *    we can't actually expose any of the compressed modifiers in case the app
++ *    chooses a compressed modifier for a non-compressed image. So for now, we
++ *    have to disable compression for TILING_DRM_FORMAT_MODIFIER_EXT images.
++ *
++ * This helper enforces these restrictions and also makes sure to enable
++ * compression for storage, color, and Z/S targets only so as to avoid pinning
++ * too many things to VRAM.
++ */
++static bool
++nvk_image_can_compress(const struct nvkmd_pdev *nvkmd_pdev,
++                       const struct nvk_image *image)
++{
++   if (nvkmd_pdev->kmd_info.has_compression) {
++      if (image->plane_count > 1 ||
++          image->vk.usage & (VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT) ||
++          image->vk.create_flags & (VK_IMAGE_CREATE_SPARSE_BINDING_BIT |
++                                    VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT))
++         return false;
++      else if (image->vk.usage & (VK_IMAGE_USAGE_STORAGE_BIT |
++                                  VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
++                                  VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) &&
++               image->vk.tiling == VK_IMAGE_TILING_OPTIMAL)
++         return true;
++      else
++         return false;
++   } else
++      return false;
++}
++
+ static VkResult
+ nvk_image_init(struct nvk_device *dev,
+                struct nvk_image *image,
+@@ -753,6 +810,16 @@ nvk_image_init(struct nvk_device *dev,
+       usage |= NIL_IMAGE_USAGE_SPARSE_RESIDENCY_BIT;
+    }
+ 
++   /* We set compression on VkImage creation in order to be able to signal to
++    * NIL that the image will be compressed which would let NIL choose the
++    * appropriate PTE kinds, and also to mark the VkImage as compressed so that
++    * in GetImageMemoryRequirements() we are able to detect it and specify that
++    * we prefer a dedicated allocation for it.
++    */
++   image->can_compress = nvk_image_can_compress(dev->nvkmd->pdev, image);
++   if (!image->can_compress)
++      usage |= nil_IMAGE_USAGE_UNCOMPRESSED_BIT;
++
+    uint32_t explicit_row_stride_B = 0;
+    if (image->vk.tiling == VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT) {
+       /* Modifiers are not supported with YCbCr */
+@@ -1098,10 +1165,23 @@ nvk_get_image_memory_requirements(struct nvk_device *dev,
+       switch (ext->sType) {
+       case VK_STRUCTURE_TYPE_MEMORY_DEDICATED_REQUIREMENTS: {
+          VkMemoryDedicatedRequirements *dedicated = (void *)ext;
+-         dedicated->prefersDedicatedAllocation =
+-            image->vk.tiling == VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT;
+-         dedicated->requiresDedicatedAllocation =
+-            image->vk.tiling == VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT;
++         if (image->vk.tiling == VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT) {
++            dedicated->prefersDedicatedAllocation = true;
++            dedicated->requiresDedicatedAllocation = true;
++         } else if (image->can_compress) {
++            /* We need dedicated allocations as compressed images have to be
++             * pinned to VRAM due to nouveau, and we can't have a separate
++             * memory type that's pinned and non evictable due to the Vulkan API
++             * disallowing equivalent image properties returning different
++             * memory types. We aren't allowed to require dedicated allocations
++             * but we can signal that we prefer them.
++             */
++            dedicated->prefersDedicatedAllocation = true;
++            dedicated->requiresDedicatedAllocation = false;
++         } else {
++            dedicated->prefersDedicatedAllocation = false;
++            dedicated->requiresDedicatedAllocation = false;
++         }
+          break;
+       }
+       default:
+@@ -1341,14 +1421,21 @@ nvk_image_plane_bind(struct nvk_device *dev,
+                                 &plane_size_B, &plane_align_B);
+    *offset_B = align64(*offset_B, plane_align_B);
+ 
+-   if (plane->va != NULL) {
+-      VkResult result = nvkmd_va_bind_mem(plane->va, &image->vk.base, 0,
+-                                          mem->mem, *offset_B,
+-                                          plane->va->size_B);
+-      if (result != VK_SUCCESS)
+-         return result;
++   if (plane->nil.pte_kind != 0) {
++      if (mem->dedicated_image == image && image->can_compress) {
++         image->is_compressed = true;
++         plane->addr = mem->mem->va->addr + *offset_B;
++      } else {
++         VkResult result = nvk_image_plane_alloc_va(dev, image, plane);
++         if (result != VK_SUCCESS)
++            return result;
++         result = nvkmd_va_bind_mem(plane->va, &image->vk.base, 0,
++                                    mem->mem, *offset_B,
++                                    plane->va->size_B);
++         if (result != VK_SUCCESS)
++            return result;
++      }
+    } else {
+-      assert(plane->nil.pte_kind == 0);
+       plane->addr = mem->mem->va->addr + *offset_B;
+    }
+ 
+diff --git a/src/nouveau/vulkan/nvkmd/nouveau/nvkmd_nouveau_pdev.c b/src/nouveau/vulkan/nvkmd/nouveau/nvkmd_nouveau_pdev.c
+index a25f7eba5bb..76ce206e029 100644
+--- a/src/nouveau/vulkan/nvkmd/nouveau/nvkmd_nouveau_pdev.c
++++ b/src/nouveau/vulkan/nvkmd/nouveau/nvkmd_nouveau_pdev.c
+@@ -14,6 +14,8 @@
+ #include <sys/stat.h>
+ #include <xf86drm.h>
+ 
++#include "clc597.h"
++
+ static bool
+ drm_device_is_nouveau(const char *path)
+ {
+@@ -105,6 +107,8 @@ nvkmd_nouveau_try_create_pdev(struct _drmDevice *drm_device,
+       .has_alloc_tiled = nouveau_ws_device_has_tiled_bo(ws_dev),
+       .has_map_fixed = true,
+       .has_overmap = true,
++      .has_compression = ws_dev->nouveau_version >= 0x01000401 &&
++                         ws_dev->info.cls_eng3d >= TURING_A,
+    };
+ 
+    /* Nouveau uses the OS page size for all pages, regardless of whether they
+diff --git a/src/nouveau/vulkan/nvkmd/nvkmd.h b/src/nouveau/vulkan/nvkmd/nvkmd.h
+index 6296c316057..36d05dea6e2 100644
+--- a/src/nouveau/vulkan/nvkmd/nvkmd.h
++++ b/src/nouveau/vulkan/nvkmd/nvkmd.h
+@@ -114,6 +114,7 @@ struct nvkmd_info {
+    bool has_alloc_tiled;
+    bool has_map_fixed;
+    bool has_overmap;
++   bool has_compression;
+ };
+ 
+ struct nvkmd_pdev_ops {
+-- 
+2.51.0
+

--- a/debian/patches/backports/0003-nvk-Disable-compression-for-image-import-export.patch
+++ b/debian/patches/backports/0003-nvk-Disable-compression-for-image-import-export.patch
@@ -1,0 +1,65 @@
+From 6191f0042ec5b025bfce1cb733d110b844751613 Mon Sep 17 00:00:00 2001
+From: Mel Henning <mhenning@darkrefraction.com>
+Date: Fri, 19 Dec 2025 10:46:38 +0800
+Subject: [PATCH 3/3] nvk: Disable compression for image import/export
+
+Reviewed-by: Mohamed Ahmed <mohamedahmedegypt2001@gmail.com>
+Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/36450>
+Signed-off-by: WangYuli <wangyl5933@chinaunicom.cn>
+---
+ src/nouveau/vulkan/nvk_device_memory.c | 15 +++++++++++----
+ src/nouveau/vulkan/nvk_image.c         |  4 +++-
+ 2 files changed, 14 insertions(+), 5 deletions(-)
+
+diff --git a/src/nouveau/vulkan/nvk_device_memory.c b/src/nouveau/vulkan/nvk_device_memory.c
+index 5ca3243bb5e..3a40063caab 100644
+--- a/src/nouveau/vulkan/nvk_device_memory.c
++++ b/src/nouveau/vulkan/nvk_device_memory.c
+@@ -139,6 +139,7 @@ nvk_AllocateMemory(VkDevice device,
+    if (fd_info != NULL)
+       handle_types |= fd_info->handleType;
+ 
++   const bool not_shared = handle_types == 0;
+    bool pinned_to_vram = false;
+ 
+    /* Align to os page size (typically 4K) as a start as this works for
+@@ -161,10 +162,16 @@ nvk_AllocateMemory(VkDevice device,
+          alignment = MAX2(alignment, image->planes[0].nil.align_B);
+          pte_kind = image->planes[0].nil.pte_kind;
+          tile_mode = image->planes[0].nil.tile_mode;
+-      } else if (image != NULL && image->can_compress) {
+-         /* If it's a dedicated alloc and it's not modifiers, then it's marked
+-          * for compression and larger pages, so we set the pinned bit and up
+-          * the alignment.
++      } else if (image != NULL && image->can_compress && not_shared) {
++         /* If it's a dedicated alloc and it's not modifiers or shared, then
++          * it's marked for compression and larger pages, so we set the pinned
++          * bit and up the alignment.
++          *
++          * Disabling compression for export/import is a bit nicer to apps.
++          * Eg. QtWebEngine likes to export/import buffers with
++          * VK_IMAGE_TILING_OPTIMAL and renders incorrectly if we remove
++          * the not_shared check.
++          * https://qt-project.atlassian.net/browse/QTBUG-141866
+           */
+          pinned_to_vram = true;
+          pte_kind = image->planes[0].nil.compressed_pte_kind;
+diff --git a/src/nouveau/vulkan/nvk_image.c b/src/nouveau/vulkan/nvk_image.c
+index 4418ad7d252..4da561e5501 100644
+--- a/src/nouveau/vulkan/nvk_image.c
++++ b/src/nouveau/vulkan/nvk_image.c
+@@ -1421,8 +1421,10 @@ nvk_image_plane_bind(struct nvk_device *dev,
+                                 &plane_size_B, &plane_align_B);
+    *offset_B = align64(*offset_B, plane_align_B);
+ 
++   const bool not_shared = !(mem->mem->flags & NVKMD_MEM_SHARED);
++
+    if (plane->nil.pte_kind != 0) {
+-      if (mem->dedicated_image == image && image->can_compress) {
++      if (mem->dedicated_image == image && image->can_compress && not_shared) {
+          image->is_compressed = true;
+          plane->addr = mem->mem->va->addr + *offset_B;
+       } else {
+-- 
+2.51.0
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -4,3 +4,6 @@ src_glx_dri_common.h.diff
 0002-add-zx-s-driver-to-mesa-s-driver-map-list-and-export.patch
 1001-zink-do-not-use-demote-on-IMG-blobs.patch
 1002-gallivm-orcjit-put-object-cache-under-the-protect.patch
+backports/0001-deepin-nvk-Add-prerequisites-for-compression-support.patch
+backports/0002-nvk-Enable-compression.patch
+backports/0003-nvk-Disable-compression-for-image-import-export.patch


### PR DESCRIPTION
[ Origin message: ]
More seriously, what this does is enable compression (commonly known as DCC and zeta compression for color and depth/stencil, respectively) for nvk. As a bonus this also enables larger page sizes (64K and 2M) for compressed images as the HW can only do compression on these page sizes.[1]

[1]. https://docs.google.com/spreadsheets/d/1RuHD3Z_nBKCp618HHC5I9hOu0lqCoFYwQ4FM69M-Ajg/edit?gid=1487969094#gid=1487969094 in the NVK game status sheet.