### PR TITLE
fix: add backport patches for egl fallback and drisw crash

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+mesa (24.3.0-1deepin7) unstable; urgency=medium
+
+  * fix: backport EGL software fallback handling fix
+  * fix: avoid crash when swrast_loader is NULL
+
+ -- ChenZiyu <czy199896@163.com>  Fri, 10 Apr 2026 17:36:19 +0800
+
 mesa (24.3.0-1deepin6) unstable; urgency=medium
 
   * perf: backport "nvk: Enable compression"

--- a/debian/patches/backports/0004-egl-fix-sw-fallback-rejection-in-non-sw-EGL_PLATFORM.patch
+++ b/debian/patches/backports/0004-egl-fix-sw-fallback-rejection-in-non-sw-EGL_PLATFORM.patch
@@ -1,0 +1,57 @@
+From 5577f21f07843d7457be79afb530e5739fbec465 Mon Sep 17 00:00:00 2001
+From: ChenZiyu <czy199896@163.com>
+Date: Fri, 10 Apr 2026 17:33:11 +0800
+Subject: [PATCH 4/5] egl: fix sw fallback rejection in non-sw
+ EGL_PLATFORM=device
+
+previously progress could still be made during sw fallback here,
+which would lead to unpredictable results with driver loading e.g., crashing
+
+cc: mesa-stable
+Part-of: <mesa/mesa!34609>
+Origin: upstream, commit 8a339cdebccdea0610bdd7a1ecc9a5ec63951940
+
+Signed-off-by: ChenZiyu <czy199896@163.com>
+---
+ src/egl/drivers/dri2/platform_device.c | 25 +++++++++++++++----------
+ 1 file changed, 15 insertions(+), 10 deletions(-)
+
+diff --git a/src/egl/drivers/dri2/platform_device.c b/src/egl/drivers/dri2/platform_device.c
+index 41ab931e..5fb3fadf 100644
+--- a/src/egl/drivers/dri2/platform_device.c
++++ b/src/egl/drivers/dri2/platform_device.c
+@@ -284,16 +284,21 @@ device_probe_device(_EGLDisplay *disp)
+    if (!dri2_dpy->driver_name)
+       goto err_name;
+ 
+-   /* When doing software rendering, some times user still want to explicitly
+-    * choose the render node device since cross node import doesn't work between
+-    * vgem/virtio_gpu yet. It would be nice to have a new EXTENSION for this.
+-    * For now, just fallback to kms_swrast. */
+-   if (disp->Options.ForceSoftware && !request_software &&
+-       (strcmp(dri2_dpy->driver_name, "vgem") == 0 ||
+-        strcmp(dri2_dpy->driver_name, "virtio_gpu") == 0)) {
+-      free(dri2_dpy->driver_name);
+-      _eglLog(_EGL_WARNING, "NEEDS EXTENSION: falling back to kms_swrast");
+-      dri2_dpy->driver_name = strdup("kms_swrast");
++   /* this is software fallback */
++   if (disp->Options.ForceSoftware && !request_software) {
++      /* When doing software rendering, some times user still want to explicitly
++      * choose the render node device since cross node import doesn't work between
++      * vgem/virtio_gpu yet. It would be nice to have a new EXTENSION for this.
++      * For now, just fallback to kms_swrast. */
++      if (strcmp(dri2_dpy->driver_name, "vgem") == 0 ||
++          strcmp(dri2_dpy->driver_name, "virtio_gpu") == 0) {
++         free(dri2_dpy->driver_name);
++         _eglLog(_EGL_WARNING, "NEEDS EXTENSION: falling back to kms_swrast");
++         dri2_dpy->driver_name = strdup("kms_swrast");
++      } else if (strcmp(dri2_dpy->driver_name, "vmwgfx")) {
++         /* this is software fallback; deny progress since a hardware device was requested */
++         return false;
++      }
+    }
+ 
+    if (!dri2_load_driver(disp))
+-- 
+2.20.1
+

--- a/debian/patches/backports/0005-drisw-Avoid-crashing-when-swrast_loader-NULL.patch
+++ b/debian/patches/backports/0005-drisw-Avoid-crashing-when-swrast_loader-NULL.patch
@@ -1,0 +1,59 @@
+From 3cbc3f4df29ddc6d078aa2a349ec36fdbdd89277 Mon Sep 17 00:00:00 2001
+From: ChenZiyu <czy199896@163.com>
+Date: Fri, 10 Apr 2026 17:34:04 +0800
+Subject: [PATCH 5/5] drisw: Avoid crashing when swrast_loader == NULL
+
+This is a blanket fix for all the segfaults in drisw_init_screen()
+when swrast_loader is NULL, since 1de7c86bc1. A similar more targeted
+fix for vmwgfx can be found in f3b8d7da46 ("egl: never select swrast
+for vmwgfx"). We can safely return NULL because the caller
+driCreateNewScreen3 handles NULL, as do its callers.
+
+As this is currently the top crasher of gnome-shell since Ubuntu
+upgraded to Mesa 25 and it seems to be coming from multiple different
+drivers still, we want a universal fix to at least stop the crash
+reports. People can figure out which drivers still need tweaking in
+dri2_load_driver or elsewhere later.
+
+Fixes: 1de7c86bc1 ("dri: pass through a type enum for creating screen instead of driver_extensions")
+Related: https://gitlab.freedesktop.org/mesa/mesa/-/issues/12678
+Related: https://gitlab.freedesktop.org/mesa/mesa/-/issues/12859
+Related: https://gitlab.freedesktop.org/mesa/mesa/-/issues/12300
+Related: https://gitlab.freedesktop.org/mesa/mesa/-/issues/12462
+Bug-Ubuntu: https://bugs.launchpad.net/bugs/2101817
+Origin: Debian
+
+Signed-off-by: ChenZiyu <czy199896@163.com>
+---
+ src/gallium/frontends/dri/drisw.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/src/gallium/frontends/dri/drisw.c b/src/gallium/frontends/dri/drisw.c
+index 4590b57e..d573e234 100644
+--- a/src/gallium/frontends/dri/drisw.c
++++ b/src/gallium/frontends/dri/drisw.c
+@@ -32,6 +32,7 @@
+ #include "util/u_memory.h"
+ #include "util/u_inlines.h"
+ #include "util/box.h"
++#include "util/log.h"
+ #include "pipe/p_context.h"
+ #include "pipe-loader/pipe_loader.h"
+ #include "frontend/drisw_api.h"
+@@ -620,6 +621,13 @@ drisw_init_screen(struct dri_screen *screen, bool driver_name_is_inferred)
+ 
+    screen->swrast_no_present = debug_get_option_swrast_no_present();
+ 
++   if (loader == NULL) {
++      /* If you are reading this then dri2_load_driver may need tweaking */
++      mesa_logw("swrast was requested but driver is missing %s",
++               __DRI_SWRAST_LOADER);
++      return NULL;
++   }
++
+    if (loader->base.version >= 4) {
+       if (loader->putImageShm)
+          lf = &drisw_shm_lf;
+-- 
+2.20.1
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -7,3 +7,5 @@ src_glx_dri_common.h.diff
 backports/0001-deepin-nvk-Add-prerequisites-for-compression-support.patch
 backports/0002-nvk-Enable-compression.patch
 backports/0003-nvk-Disable-compression-for-image-import-export.patch
+backports/0004-egl-fix-sw-fallback-rejection-in-non-sw-EGL_PLATFORM.patch
+backports/0005-drisw-Avoid-crashing-when-swrast_loader-NULL.patch


### PR DESCRIPTION
Add two backport patches:
- egl: fix sw fallback rejection in non-sw EGL_PLATFORM=device
- drisw: Avoid crashing when swrast_loader == NULL

Origin:
- upstream: https://gitlab.freedesktop.org/mesa/mesa/-/commit/8a339cdebccdea0610bdd7a1ecc9a5ec63951940
- Debian: https://lists.debian.org/debian-x/2025/04/msg00042.html